### PR TITLE
fix: sys comes prebaked with python, no need to specify it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 playwright
 colorama
 typing
-sys


### PR DESCRIPTION
For the life of me I couldn't get past the installation until I removed this line. According to Docs:

`sys is a built-in module in Python and does not need to be installed as a package.`

After that I was able to build this and get this loaded as as plugin!
![Screen Shot 2023-05-03 at 1 26 59 PM](https://user-images.githubusercontent.com/1424113/236041923-ebab569e-ef2d-440e-a17c-7a0315e4851c.png)

